### PR TITLE
Add ticket linking workflow

### DIFF
--- a/.github/workflows/link-issues-by-milestone.yml
+++ b/.github/workflows/link-issues-by-milestone.yml
@@ -1,0 +1,56 @@
+name: Link issue to cross-repo milestone parent
+
+on:
+  issues:
+    types: [milestoned]
+
+jobs:
+  link:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Link to parent issue in aind-scientific-computing
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SERVICE_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const milestone = issue.milestone;
+
+            if (!milestone) return;
+
+            const targetOwner = "AllenNeuralDynamics";
+            const targetRepo = "aind-scientific-computing";
+
+            const url = milestone.description;
+            const match = url?.match(/\/issues\/(\d+)$/);
+
+            if (!match) {
+              console.log(`Milestone description is not a roadmap URL: ${url}`);
+              return;
+            }
+
+            const parentNumber = parseInt(match[1]);
+
+            const { data: parent } = await github.rest.issues.get({
+              owner: targetOwner,
+              repo: targetRepo,
+              issue_number: parentNumber
+            });
+
+            if (!parent) {
+              console.log(`No issue found at ${url}`);
+              return;
+            }
+
+            await github.request("POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues", {
+              owner: targetOwner,
+              repo: targetRepo,
+              issue_number: parentNumber,
+              sub_issue_id: issue.id,
+              headers: {
+                "X-GitHub-Api-Version": "2022-11-28"
+              }
+            });
+
+            console.log(`Linked issue #${issue.number} as sub-issue of ${targetRepo}#${parentNumber}`);


### PR DESCRIPTION
Adds `link-issues-by-milestone.yml` to automatically link issues to their parent roadmap item in `aind-scientific-computing` when assigned to a milestone. The milestone description should contain the URL of the parent roadmap issue.